### PR TITLE
deprecation-fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ plugins.push(new SpineSpriteWebpackPlugin({ padding: 5 }));
 ```
 
 ### Settings of loader
-You will need to set options for your loader only.
-The best way to do that - using inline options.
+The best way to set options for your loader - using inline options.
 
 Set scale option. This allows you to resolve skeleton, his assets,
 scale them and final animation. 

--- a/src/Plugin/index.js
+++ b/src/Plugin/index.js
@@ -37,7 +37,10 @@ module.exports = class SpineSpriteMapWebpackPlugin {
     this.cacheCompilerDir = cacheThunk(compiler.name || compiler.options.name || '');
 
     compiler.hooks.thisCompilation.tap(pluginName, (compilation) => {
-      compilation.hooks.normalModuleLoader.tap(pluginName, (spineLoader) => {
+      const loader = compiler.webpack && compiler.webpack.NormalModule
+        ? compiler.webpack.NormalModule.getCompilationHooks(compilation).loader
+        : compilation.hooks.normalModuleLoader;
+      loader.tap(pluginName, (spineLoader) => {
         spineLoader[pluginName] = this; // eslint-disable-line no-param-reassign
       });
     });


### PR DESCRIPTION
Fixed warning
`[DEP_WEBPACK_COMPILATION_NORMAL_MODULE_LOADER_HOOK] DeprecationWarning: Compilation.hooks.normalModuleLoader was moved to NormalModule.getCompilationHooks(compilation).loader`
